### PR TITLE
WIP: `calculateMetadata()` for dynamic duration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
 	"repository": {},
 	"license": "UNLICENSED",
 	"dependencies": {
-		"@remotion/cli": "^4.0.0",
-		"@remotion/media-utils": "^4.0.0",
-		"@remotion/zod-types": "^4.0.0",
+		"@remotion/cli": "4.0.4",
+		"@remotion/media-utils": "4.0.4",
+		"@remotion/zod-types": "4.0.4",
 		"parse-srt": "1.0.0-alpha",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0",
-		"remotion": "^4.0.0",
+		"remotion": "4.0.4",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {
-		"@remotion/eslint-config": "^4.0.0",
+		"@remotion/eslint-config": "4.0.4",
 		"@types/react": "^18.0.26",
 		"@types/web": "^0.0.91",
 		"eslint": "^8.43.0",

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -43,6 +43,7 @@ export const RemotionRoot: React.FC = () => {
 					waveNumberOfSamples: '256', // This is string for Remotion controls and will be converted to a number
 					mirrorWave: true,
 				}}
+				// Determine the lengt of the video based on the duration of the audio file
 				calculateMetadata={async ({ props }) => {
 					const audioDurationInSec = Math.ceil(
 						await getAudioDurationInSeconds(props.audioFileName)

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,6 +1,7 @@
 import { Composition, staticFile } from 'remotion';
 import { AudioGramSchema, AudiogramComposition } from './Composition';
 import './style.css';
+import { getAudioDurationInSeconds } from '@remotion/media-utils';
 
 const fps = 30;
 const durationInFrames = 29.5 * fps;
@@ -41,6 +42,16 @@ export const RemotionRoot: React.FC = () => {
 					waveLinesToDisplay: 29,
 					waveNumberOfSamples: '256', // This is string for Remotion controls and will be converted to a number
 					mirrorWave: true,
+				}}
+				calculateMetadata={async ({ props }) => {
+					const audioDurationInSec = Math.ceil(
+						await getAudioDurationInSeconds(props.audioFileName)
+					);
+
+					return {
+						durationInFrames: audioDurationInSec * fps,
+						props,
+					};
 				}}
 			/>
 		</>


### PR DESCRIPTION
Using `calculateMetadata()` to get dynamic duration based on the duration of the selected audio file. 